### PR TITLE
Update idx.ex

### DIFF
--- a/go_api/lib/go_api/idx.ex
+++ b/go_api/lib/go_api/idx.ex
@@ -1,54 +1,57 @@
 defmodule GoApi.Idx do
 
   import GoApi.Conf
-  @api_key api_key() # Mendefinisikan atribut module api_key
+  @api_key_stock api_key_stock() # Mendefinisikan atribut module api_key
 
  @moduledoc """
   Get data for companies listed on IDX (Indonesia Stock Exchange).
   """
 
   def companies do
-    get_api_params("stock/idx/companies?api_key=#{@api_key}")
+    get_api_params("stock/idx/companies?api_key=#{@api_key_stock}")
   end
 
   def indices do
-    get_api_params("stock/idx/indices?api_key=#{@api_key}")
+    get_api_params("stock/idx/indices?api_key=#{@api_key_stock}")
   end
 
   def index_items(symbol \\ "MNC36") do
-    get_api_params("stock/idx/index/#{symbol}/items?&api_key=#{@api_key}")
+    get_api_params("stock/idx/index/#{symbol}/items?&api_key=#{@api_key_stock}")
   end
-
 
   def emitent_detail(emitent_symbol \\ "BMRI") do
-    get_api_params("stock/idx/#{emitent_symbol}?api_key=#{@api_key}")
+    get_api_params("stock/idx/#{emitent_symbol}/profile?api_key=#{@api_key_stock}")
   end
 
-
   def stock_prices(symbol_list \\ "BBRI,BBCA") do
-    get_api_params("stock/idx/prices?symbols=#{symbol_list}&api_key=#{@api_key}")
+    get_api_params("stock/idx/prices?symbols=#{symbol_list}&api_key=#{@api_key_stock}")
   end
 
   def trending_stocks do
-    get_api_params("stock/idx/trending?api_key=#{@api_key}")
+    get_api_params("stock/idx/trending?api_key=#{@api_key_stock}")
   end
 
   def top_gainers do
-    get_api_params("stock/idx/top_gainer?api_key=#{@api_key}")
+    get_api_params("stock/idx/top_gainer?api_key=#{@api_key_stock}")
   end
 
-
   def top_losers do
-    get_api_params("stock/idx/top_loser?api_key=#{@api_key}")
+    get_api_params("stock/idx/top_loser?api_key=#{@api_key_stock}")
   end
 
   def historical_stock_data(%{"symbol" => symbol, "date_from" => date_from, "date_to" => date_to} \\ %{"symbol" => "BBCA", "date_from" => "2023-01-01", "date_to" => "2023-03-01"}) do
-    get_api_params("stock/idx/#{symbol}/historical?from=#{date_from}&to=#{date_to}&api_key=#{@api_key}")
+    get_api_params("stock/idx/#{symbol}/historical?from=#{date_from}&to=#{date_to}&api_key=#{@api_key_stock}")
   end
 
+  def e_ipo do
+  get_api_params("stock/idx/e-ipo?api_key=#{@api_key_stock}")
+  end
+  def broker_summary(%{"symbol" => symbol, "date" => date} \\ %{"symbol" => "BBCA", "date" => "2023-10-30"}) do
+    get_api_params("stock/idx/#{symbol}/broker_summary?date=#{date}&api_key=#{@api_key_stock}")
+  end
 
-  def broker_summary(%{"symbol" => symbol, "date_from" => date_from, "date_to" => date_to} \\ %{"symbol" => "BBCA", "date_from" => "2023-01-01", "date_to" => "2023-03-01"}) do
-    get_api_params("stock/idx/#{symbol}/broker_summary?from=#{date_from}&to=#{date_to}&api_key=#{@api_key}")
+  def indicators(%{"limit_page" => limit_pages, "date" => date} \\ %{"limit_page" => "", "date" => ""}) do
+  get_api_params("stock/idx/indicators?page=#{limit_pages}&date=#{date}&api_key=#{@api_key_stock}")
   end
 
 end


### PR DESCRIPTION
   - Replaced the generic `@api_key` variable with specific `@api_key_stock` to clearly denote the API key for IDX-related operations. This change ensures better organization and understanding of the codebase.

   - Added a new function `e_ipo/0` to retrieve data for electronic initial public offerings (e-IPO) on IDX. The function uses the specified API key for authentication.

   - Introduced the `indicators/1` function to fetch stock market indicators based on the provided parameters, including limit page and date. The function allows for more dynamic querying of indicator data from the API.

   - Updated the `emitent_detail/1` function to access the `profile` endpoint instead of the generic endpoint. This ensures accurate retrieval of issuer (emitent) details from IDX.

   - Modified the `broker_summary/1` function to accept a specific date parameter for retrieving broker summary data. This change enables users to specify the date for which they want the broker summary information.